### PR TITLE
📝 Add dive to feature catalog

### DIFF
--- a/docs/editor/authentication.md
+++ b/docs/editor/authentication.md
@@ -74,17 +74,20 @@ docker run \
 
 ### File-Based Passwords
 
-Instead of passing passwords as environment variables, you can mount them as files.
-This is useful with Docker secrets or mounted credential files.
+Instead of passing passwords as environment variables, you can mount them as files
+*(useful with Docker secrets or Kubernetes `Secret` projections)*.
+Point the variable at the file with the `file:` prefix, or mount the file at the
+convention path and leave the variable unset.
 
-- <EnvVar group="auth" name="password_file" />
-- <EnvVar group="auth" name="password_hashed_file" />
-
-```sh{3-4}
+```sh{2-3}
 docker run \
-  ghcr.io/kloudkit/workspace:v0.2.1 \
-  -v ./my_hashed_password.txt:/run/secrets/workspace/auth_password_hashed
+  -e WS_AUTH_PASSWORD_HASHED=file:/run/secrets/workspace/auth/password_hashed \
+  -v ./password_hashed.txt:/run/secrets/workspace/auth/password_hashed:ro \
+  ghcr.io/kloudkit/workspace:v0.2.1
 ```
+
+See [Resolving Secret Values](/settings/configuration#resolving-secret-values)
+for the full resolution chain and Kubernetes example.
 
 ### Rate Limiting
 

--- a/docs/editor/features.md
+++ b/docs/editor/features.md
@@ -174,8 +174,9 @@ For more information, visit our [contribution guide](/contribute/).
 | `codex`                     | codex CLI                                  | *v0.0.20* |       |
 | `conan`                     | Conan CLI and related tools                | *v0.0.21* |       |
 | `continue`                  | cn CLI and continue extension              |           |       |
-| `cpp`                       | C++ and related tools                      |           |   ✅   |
+| [**`cpp →`**](/tools/cpp)   | C++ and related tools                      |           |   ✅   |
 | `dagger`                    | dagger.io CLI and SDK                      |           |       |
+| `dive`                      | Image-layer explorer TUI                   |           |       |
 | `doctl`                     | DigitalOcean CLI                           | *v0.2.0*  |       |
 | `dotnet`                    | .NET framework and related extensions      |           |   ✅   |
 | `gcloud`                    | Google Cloud CLI for GCP                   |           |   ✅   |

--- a/docs/settings/configuration.md
+++ b/docs/settings/configuration.md
@@ -2,6 +2,8 @@
 see:
   - name: Editor Settings
     link: /editor/settings
+  - name: Secrets
+    link: /settings/secrets
 ---
 
 # Configuration
@@ -32,6 +34,64 @@ Such variables can be reviewed in the [global variables](#global-variables) sect
 
 ::: tip Boolean Values
 To enable a boolean environment variable, set it to a *truthy* value, either `1` or `true`.
+:::
+
+## Resolving Secret Values
+
+Secret-shaped variables resolve through a four-step chain so the same property works across
+Docker and Kubernetes without `_FILE` companions:
+
+- <EnvVar group="auth" name="password" />
+- <EnvVar group="auth" name="password_hashed" />
+- <EnvVar group="auth" name="github_token" />
+- <EnvVar group="secrets" name="master_key" />
+- <EnvVar group="server" name="ssl_cert" />
+- <EnvVar group="server" name="ssl_key" />
+
+The resolver returns the first match:
+
+1. **Env literal:** `WS_X=value`.
+2. **`file:` prefix:** `WS_X=file:/path` reads the file *(one trailing newline stripped, internal newlines preserved)*.
+3. **Convention default:** mount a file at `/run/secrets/workspace/<group>/<property>` and leave
+   the variable unset.
+4. **Schema default:** typically unset.
+
+::: code-group
+
+```sh [Env literal]
+docker run \
+  -e WS_AUTH_PASSWORD=super_duper_secret \
+  ghcr.io/kloudkit/workspace:v0.2.1
+```
+
+```sh [file: prefix]
+docker run \
+  -e WS_AUTH_PASSWORD=file:/run/secrets/workspace/auth/password \
+  -v ./password.txt:/run/secrets/workspace/auth/password:ro \
+  ghcr.io/kloudkit/workspace:v0.2.1
+```
+
+```yaml [Kubernetes]
+volumes:
+  - name: workspace-secrets
+    secret:
+      secretName: workspace-secrets
+      items:
+        - key: password
+          path: auth/password
+containers:
+  - name: workspace
+    volumeMounts:
+      - name: workspace-secrets
+        mountPath: /run/secrets/workspace
+        readOnly: true
+```
+
+:::
+
+::: tip
+`ws-cli show env <KEY>` reports where the value came from: `env-set`, `env-file`,
+`secret-file-default`, or `yaml-default`.
 :::
 
 <!--@include: ../partials/environment-variables.md -->


### PR DESCRIPTION
## Summary

- Adds `dive` row to the opt-in feature table in `docs/editor/features.md` (between `dagger` and `doctl`).
- Includes the existing cpp-tool link upgrade that was already in the table edit.

Pairs with `kloudkit/workspace#655`, which moves dive from baked-default to an opt-in feature playbook (`WS_FEATURES_ADDITIONAL_FEATURES=dive`). The auto-generated dependencies table will drop dive automatically on the next `kloudkit/ws-meta` `distribute.yaml` sync; this PR covers the hand-authored feature catalog only.

## Test plan

- [ ] Visual diff renders cleanly on a docs-site preview.