### PR TITLE
📜 Render the workspace changelog as a docs page

### DIFF
--- a/.vitepress/_nav.ts
+++ b/.vitepress/_nav.ts
@@ -1,4 +1,5 @@
 export default [
+  { text: 'Changelog', link: '/changelog' },
   {
     text: 'Get Involved',
     items: [

--- a/.vitepress/_sidebar.ts
+++ b/.vitepress/_sidebar.ts
@@ -20,6 +20,7 @@ export default {
   '/': [
     { text: 'Introduction', link: '/pages' },
     { text: 'Getting Started', link: '/pages/getting-started' },
+    { text: 'Changelog', link: '/changelog' },
     {
       text: 'Get Involved',
       collapsed: true,

--- a/.vitepress/data/CHANGELOG.md
+++ b/.vitepress/data/CHANGELOG.md
@@ -1,0 +1,114 @@
+# Changelog
+
+## [0.4.0] — 2026-06-23
+
+### Added
+
+- ✨ dotnet: Debian 13 trixie + selectable version bands (8.0/9.0/10.0)
+- ✨ Install additional pip packages and uv tools via env vars (#703)
+- ✨ Install additional npm packages via `WS_NPM_ADDITIONAL_PACKAGES`
+- ✨ Run `cloudflared` as a supervised s6 tunnel daemon (#700)
+- ✨ Skip feature-install sections via `--skip-*` flags (#698)
+- ✨ Enable built-in Markdown features and markdownlint parity (#697)
+- ✨ Add user feature playbooks under `~/.ws/features.d` (#696)
+- ✨ Query `show env` by canonical dotted keys, retire WS_* query form (#693)
+- ✨ Enforce WS_* value validation via declared patterns
+- ✨ Retire common.sh env wrappers into `ws-cli show env`
+- ✨ Add in-workspace OIDC auth via oauth2-proxy (#690)
+- ✨ Add fonts.yaml manifest and render to fonts.sh (#683)
+
+### Changed
+
+- 🏗️ Automate release tagging and changelog from a WS_VERSION literal (#722)
+- ♻️ dotnet: DRY the version var, trim zshenv comments
+- 🚚 Move shell/REPL history to `~/.ws/history` and consolidate env into `zshenv` (#704)
+- ♻️ Extract `github_binary` role task and sweep feature playbooks (#701)
+- 🚚 Replace `dumb-init` with `s6-overlay` v3 daemon supervision (#699)
+- 🏗️ Audit image build: isolate code-server into a cache-stable stage (#695)
+- 🏗️ Audit dependency manifest: sudo PATH parity + Renovate hygiene (#694)
+
+### Fixed
+
+- 🐛 Fixed renovate syntax
+- 🐛 Own proxy-domain {{port}} prefix in startup, reject wildcards
+
+## [0.3.0] — 2026-06-01
+
+### Added
+
+- ✨ Add a `--target` flag to `ws-cli logs` for the metrics and `dockerd` components
+- ✨ Add the `ripgrep` fast recursive search tool
+- ✨ Add the `tshark` terminal network-protocol analyzer
+- ✨ Add GitHub authentication support
+- ✨ Bundle the `syft`, `grype`, `dive`, and `osv-scanner` SBOM and vulnerability tools as an `image-extras` feature
+- ✨ Add a `version` option to the `cpp` feature and support offline installation
+- ✨ Add a `WS_APT_DISABLE_RESTRICTIONS` toggle
+
+### Changed
+
+- 🏗️ Slim the dev image and install `pnpm` from npm
+- 🏗️ Render `extensions.sh` from a new `extensions.yaml` manifest
+- 🏗️ Harden the `~/.ws/` convention: add `ca.d/` and drop the override environment variables
+- 🏗️ Resolve the pip and npm registries from the environment or user config
+- 🏗️ Add a drift-safe APT resolver for `ws-feature-store` drift
+- 🏗️ Route additional APT installs through a feature playbook
+- 🚚 Move `dive` to an opt-in feature
+- ♻️ Migrate secret-shaped and path-shaped `WS_*` variables to the `secret: true` and `type: path` schema flags
+- ♻️ Read every `WS_*` variable through `ws-cli show env`, dropping `check_env_set` and `resolve_secret`
+- 🏗️ Add `server.ssl_root` and an absolute `secrets.vault` default
+
+### Removed
+
+- 🔥 Trim dead-weight bundled assets from the VSCode extensions
+
+### Fixed
+
+- 🐛 Fix a prompt-hide regression and harden the zsh shell-init layer
+- 🐛 Harden the workspace startup scripts for first boot
+- 🐛 Fix the Claude statusline ahead/behind icons to match starship
+- 🐛 Fix web-font loading and cache the static assets
+- 🐛 Rename `server.root_dir` to `server.root` to match the runtime environment variable
+- 🐛 Stamp debug "Skipped" lines from the `common.sh` environment helpers
+
+### Security
+
+- 🔒 Deny CNI plugins by default
+
+### Dependencies
+
+- ⬆️ Bump the `base-image` to `v0.1.1`
+- ⬆️ Bump `ws-cli`
+- ⬆️ Bump `ansible-core` to `v2.21.0`
+
+## [0.2.1] — 2026-05-05
+
+### Dependencies
+
+- ⬆️ Bump `kubectl`
+
+## [0.2.0] — 2026-04-27
+
+### Added
+
+- ✨ Add the GitLab CLI
+- ✨ Add the `claude-code` CLI
+- ✨ Add the `bun` JavaScript runtime as a feature
+- ✨ Add a `notify` endpoint to the IPC interface
+- ✨ Add an opt-in open-code (`oc`) environment
+- ✨ Support a custom `.ws` configuration directory
+
+### Changed
+
+- 🚚 Move `oc` into a feature
+- 🚚 Migrate to `uv` for Python package management
+- 🚚 Move delimited parsing to the `dilimit` helper
+- 🏗️ Source features from `ws-feature-store`
+- 🏗️ Package build artifacts as well
+
+### Fixed
+
+- 🐛 Fix `fzf` history search
+
+### Dependencies
+
+- ⬆️ Update Helm to v4

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,12 @@
+---
+description: Release notes for Kloud Workspace, generated from commit history of each tagged release
+editLink: false
+---
+
+# Changelog
+
+Release notes for each tagged Kloud Workspace image, generated from the commit history.
+
+The newest release is listed first.
+
+<!--@include: ./partials/changelog.md -->

--- a/docs/partials/.gitignore
+++ b/docs/partials/.gitignore
@@ -1,3 +1,4 @@
+changelog.md
 dependencies.md
 deprecated-variables.md
 environment-variables.md

--- a/scripts/generate-all.mjs
+++ b/scripts/generate-all.mjs
@@ -6,3 +6,4 @@ execSync("node ./scripts/generate-environment-variables.mjs", { stdio: "inherit"
 execSync("node ./scripts/generate-extensions.mjs", { stdio: "inherit" })
 execSync("node ./scripts/generate-fonts.mjs", { stdio: "inherit" })
 execSync("node ./scripts/generate-fs-manifest.mjs", { stdio: "inherit" })
+execSync("node ./scripts/generate-changelog.mjs", { stdio: "inherit" })

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -1,0 +1,21 @@
+import fs from 'node:fs'
+import { resolve } from 'node:path'
+
+const DATA_PATH = resolve('.vitepress/data/CHANGELOG.md')
+const OUT_PATH = resolve('docs/partials/changelog.md')
+const PLACEHOLDER = '*Pending first changelog sync from `workspace` CI.*\n'
+
+if (!fs.existsSync(DATA_PATH)) {
+  fs.writeFileSync(OUT_PATH, PLACEHOLDER)
+  console.log('✔ docs/partials/changelog.md updated (placeholder — data file missing)')
+  process.exit(0)
+}
+
+const raw = fs.readFileSync(DATA_PATH, 'utf8')
+
+// Strip the leading `# Changelog` header block (git-cliff header); the host
+// page owns the page heading and frontmatter.
+const body = raw.replace(/^#\s+Changelog\s*\n+/, '').trimStart()
+
+fs.writeFileSync(OUT_PATH, `${body.replace(/\s*$/, '')}\n`)
+console.log('✔ docs/partials/changelog.md updated')


### PR DESCRIPTION
Part 3/3 of **2026-q2-50 public-release-surface** (ws-docs leg). Depends on the workspace + ws-meta PRs (which route the synced `CHANGELOG.md` here).

Adds a public **Changelog** page, fed by the synced `workspace/CHANGELOG.md` through the house data→generator→partial pattern.

## Changes
- **`scripts/generate-changelog.mjs`** (new) — strips git-cliff's `# Changelog` header from `.vitepress/data/CHANGELOG.md` into a gitignored `docs/partials/changelog.md` (graceful placeholder when the data file isn't synced yet). Mirrors `generate-fs-manifest.mjs`.
- **`scripts/generate-all.mjs`** — register the generator (runs on `prebuild`).
- **`docs/changelog.md`** (new) — thin hand-authored host page (frontmatter + heading + `@include` of the partial). Normally linted.
- **`docs/partials/.gitignore`** — add `changelog.md` (generated, like every other partial).
- **`.vitepress/_nav.ts` + `_sidebar.ts`** — add the `Changelog` entry.
- **`.vitepress/data/CHANGELOG.md`** — seed the first arrival.

## No lint-ignore
The `workspace` `.cliff.toml` now emits markdownlint-clean output (companion PR), so the synced data file lints as a normal tracked file — **no `.markdownlintignore`** and no `.prettierignore` (prettier isn't in this repo's toolchain). Full `pre-commit run --all-files` is green; `docs:build` renders the page (v0.4.0 → v0.2.0).

## Placement
`/changelog` (root-level top-level segment) — a standalone reference surface, peer to `/editor`, `/tools`; not nested under `/pages` (intro prose). Nelson-confirmed.